### PR TITLE
Fixed an error with the latest version of the menu

### DIFF
--- a/src/zeroMenu2.lua
+++ b/src/zeroMenu2.lua
@@ -15,8 +15,8 @@ require("ZeroMenuLib/enums/VehicleHash")
 
 
 local ignoreplayers
-configpath = os.getenv("APPDATA") .. "\\PopstarDevs\\2Take1Menu\\scripts\\ZeroMenuLib\\data\\config.cfg"
-configfolder = os.getenv("APPDATA") .. "\\PopstarDevs\\2Take1Menu\\scripts\\ZeroMenuLib\\data"
+configpath = os.getenv('APPDATA') .. "\\PopstarDevs\\2Take1Menu\\scripts\\ZeroMenuLib\\data\\config.cfg"
+configfolder = os.getenv('APPDATA') .. "\\PopstarDevs\\2Take1Menu\\scripts\\ZeroMenuLib\\data"
 
 function zeroMenuMain()
   if not utils.dir_exists(configfolder) then


### PR DESCRIPTION
I kept getting an error when trying to execute the Menu. The exact error was 
![image](https://user-images.githubusercontent.com/3095402/104564474-8f629480-5610-11eb-93dc-4648de8c7a16.png)
"attempt to index a nil value (global 'Config')"

By changing os.getenv("APPDATA") to os.getenv('APPDATA') it fixed the issue.

I was able to load the Menu without any issue afterwards